### PR TITLE
UI Fix for Chart Balance.

### DIFF
--- a/src/components/Details/Detail.js
+++ b/src/components/Details/Detail.js
@@ -51,10 +51,8 @@ const Detail = ({ title }) => {
       }}
     >
       <Card>
-        <CardHeader title={title} />
+        <CardHeader title={`${title}($${total})`}></CardHeader>
         <CardContent>
-          <Typography variant="h5">Total Balance ${total}</Typography>
-
           {/* Chart */}
           <Doughnut data={data} width="100%" height="50px" />
         </CardContent>


### PR DESCRIPTION
I improved the UI to put balance in this way.
<img width="238" alt="image" src="https://github.com/user-attachments/assets/b6866d7b-03d3-4878-8db1-57f314cdb86f">

previously it was this:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/edb29bbc-51b3-4e6a-ae8d-e72ff60c04c5">
